### PR TITLE
优化 Build 时文章数据的获取策略

### DIFF
--- a/config.js
+++ b/config.js
@@ -15,13 +15,10 @@ module.exports = {
     blog: {
         sourceType: 'notion',
         url: 'https://www.notion.so/gine/b8081728310b49fea0ff1d14e190b3fb?v=dbd9df2e8f784aa7bf8db977d82ee635',
-
+        
         // 建议开启，可以大大提高build速度
         // 访问 https://github.com/settings/tokens 获取token 
         // export GitHubToken='yourtokenhere'
-        cache: {
-            source: `local` // or github
-        },
         openGithubCache: true, // 开启此配置后，notion页面的数据会缓存到github仓库。需要在环境变量中配置 GitHubToken
         github: {
             username: 'mayneyao', // github 用户名

--- a/config.js
+++ b/config.js
@@ -19,6 +19,9 @@ module.exports = {
         // 建议开启，可以大大提高build速度
         // 访问 https://github.com/settings/tokens 获取token 
         // export GitHubToken='yourtokenhere'
+        cache: {
+            source: `local` // or github
+        },
         openGithubCache: true, // 开启此配置后，notion页面的数据会缓存到github仓库。需要在环境变量中配置 GitHubToken
         github: {
             username: 'mayneyao', // github 用户名

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -6,17 +6,13 @@ conf = {
     siteMetadata: config.blogMeta,
     plugins: [
         `gatsby-plugin-react-helmet`,
+        {
+            resolve: "gatsby-plugin-netlify-cache",
+            options: {
+                cachePublic: true
+            }
+        },
     ],
-}
-
-
-if (config.blog.cache.source === 'local') {
-    conf.plugins.push({
-        resolve: "gatsby-plugin-netlify-cache",
-        options: {
-            cachePublic: true
-        }
-    })
 }
 
 if (config.ga.open) {
@@ -103,7 +99,7 @@ if (config.rss.open) {
 }
 
 
-if (config.blog.cache.source === 'github' && config.blog.openGithubCache && !process.env.GitHubToken) {
+if (config.blog.openGithubCache && !process.env.GitHubToken) {
     throw Error('因为您开启了github仓库缓存notion文章，请配置环境变量 GitHubToken')
 }
 

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -10,6 +10,15 @@ conf = {
 }
 
 
+if (config.blog.cache.source === 'local') {
+    conf.plugins.push({
+        resolve: "gatsby-plugin-netlify-cache",
+        options: {
+            cachePublic: true
+        }
+    })
+}
+
 if (config.ga.open) {
     conf.plugins.push({
         resolve: `gatsby-plugin-google-analytics`,

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -103,7 +103,7 @@ if (config.rss.open) {
 }
 
 
-if (config.blog.openGithubCache && !process.env.GitHubToken) {
+if (config.blog.cache.source === 'github' && config.blog.openGithubCache && !process.env.GitHubToken) {
     throw Error('因为您开启了github仓库缓存notion文章，请配置环境变量 GitHubToken')
 }
 

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "gatsby-plugin-google-analytics": "^2.0.9",
     "gatsby-plugin-guess-js": "^1.1.0",
     "gatsby-plugin-manifest": "^2.0.13",
+    "gatsby-plugin-netlify-cache": "^1.2.0",
     "gatsby-plugin-offline": "^2.0.21",
     "gatsby-plugin-react-helmet": "^3.0.5",
     "gatsby-plugin-sitemap": "^2.0.4",

--- a/src/components/bangumi/api.js
+++ b/src/components/bangumi/api.js
@@ -19,11 +19,9 @@ getBangumiData = async () => {
 
 
 async function genBangumiData(createNode, createNodeId, createContentDigest) {
-
-    console.log('>>>获取bangumi数据')
-    let bangumiData = await getBangumiData()
     if (config.bangumi.open) {
-        res = bangumiData
+        console.log('>>>获取bangumi数据')
+        res = await getBangumiData()
     } else {
         // 站位数据，没有实际意义，为了保证build通过
         res = [

--- a/src/notion/syncBlog.js
+++ b/src/notion/syncBlog.js
@@ -126,7 +126,7 @@ getBlogInfoData = async (item, allBlogInfoFromGithub) => {
             update_time,
             source: 'local'
         }
-    } else if (config.blog.openGithubCache && allBlogInfo) {
+    } else if (config.blog.openGithubCache && allBlogInfoFromGithub) {
         // 从 github 获取博客内容
         let blogKey = `${item.slug}.json`
         let blogSha = allBlogInfoFromGithub[blogKey]

--- a/src/notion/syncBlog.js
+++ b/src/notion/syncBlog.js
@@ -1,9 +1,15 @@
 const puppeteer = require('puppeteer');
-const Axios = require('axios');
 const GitHub = require('../github/api');
 const dayjs = require('dayjs');
 const config = require('../../config');
 const notion = require('./api');
+const fs = require("fs")
+const path = require("path")
+
+function generateBrief(text, length) {
+    return text.replace(/<[^>]*>|/g, "").substr(0, length)
+}
+
 
 syncBlogData = async (url) => {
     const browser = await puppeteer.launch();
@@ -84,91 +90,109 @@ uploadBlogData2Github = async (item, blogData) => {
 }
 
 
+createBlogPostNode = (blogData, item, createNode, createNodeId, createContentDigest) => {
+    let data = { ...item, update_time: item.last_edited_time, slug: `posts/${item.slug}`, html: blogData.html, brief: blogData.brief }
+    const nodeContent = JSON.stringify(data)
+    const nodeMeta = {
+        id: createNodeId(data.slug),
+        parent: null,
+        children: [],
+        internal: {
+            type: `Post`,
+            mediaType: `text/html`,
+            content: nodeContent,
+            contentDigest: createContentDigest(data)
+        }
+    }
+    const node = Object.assign({}, data, nodeMeta)
+    createNode(node)
+}
+
+
+getBlogInfoData = async (item, allBlogInfoFromGithub) => {
+    if (config.blog.cache.source === 'local') {
+        // 从本地获取博客内容
+        let rootPath = path.dirname(path.dirname(__dirname))
+        let localPostDataPath = `${rootPath}/public/page-data/posts/${item.slug}/page-data.json`
+        console.log(`从本地获取文章缓存: ${item.name}`)
+        if (fs.existsSync(localPostDataPath)) {
+            let allData = fs.readFileSync(localPostDataPath)
+            let postData = JSON.parse(allData)
+            const { update_time, html } = postData.result.data.post
+            return {
+                blogData: {
+                    brief: generateBrief(html, 100),
+                    html
+                },
+                update_time,
+                source: 'local'
+            }
+        } else {
+            return {
+                source: 'local'
+            }
+        }
+
+    } else if (config.blog.openGithubCache && allBlogInfo) {
+        // 从 github 获取博客内容
+        let blogKey = `${item.slug}.json`
+        let blogSha = allBlogInfoFromGithub[blogKey]
+        if (blogSha) {
+            // 存在旧blog数据
+            let githubBlogData = await GitHub.getBlogData(blogSha)
+            return {
+                blogData: githubBlogData.content,
+                update_time: githubBlogData.update_time,
+                source: 'github'
+            }
+        } else {
+            return {
+                source: 'github'
+            }
+        }
+
+    }
+}
+
 exports.syncNotionBlogData = async ({ createNode, createNodeId, createContentDigest }) => {
 
     if (config.blog.sourceType === 'notion') {
         let url = config.blog.url
         let res = await notion.queryCollection(url)
-
+        let allBlogInfoFromGithub
         res = res.filter(item => item && item.public_date && item.status == '已发布')
         if (config.blog.openGithubCache) {
             // 开启github 文章缓存
-            let allBlogInfo = await GitHub.getAllBlogInfo()
-
-            for (let item of res) {
-                let blogData
-                let blogKey = `${item.slug}.json`
-                let blogSha = allBlogInfo[blogKey]
-                let isFromGithubCache = true
-                if (blogSha) {
-                    // 存在旧blog数据
-                    let githubBlogData = await GitHub.getBlogData(blogSha)
-                    if (dayjs(item.last_edited_time) > dayjs(githubBlogData.update_time)) {
-                        // 文章需要更新
-                        console.log(`>>>开始同步文章:${item.name} from notion \n`)
-                        blogData = await syncBlogData(item.browseableUrl);
-                        isFromGithubCache = false
-                        await uploadBlogData2Github(item, blogData)
-
-                    } else {
-                        // 文章不需要更新，获取来自github的缓存数据
-                        blogData = githubBlogData.content
+            allBlogInfoFromGithub = await GitHub.getAllBlogInfo()
+        }
+        for (let item of res) {
+            let blogData
+            let blogInfoData = await getBlogInfoData(item, allBlogInfoFromGithub)
+            if (blogInfoData.blogData && blogInfoData.update_time) {
+                // 文章需要更新 & 启用github缓存，需要同步到github
+                if (dayjs(item.last_edited_time) > dayjs(blogInfoData.update_time)) {
+                    if (blogInfoData.source === 'local') {
+                        console.log(`>>>本地文章已经过期：${item.name}`)
                     }
-
-                } else {
-                    // 不存在blog 数据
                     console.log(`>>>开始同步文章:${item.name} from notion \n`)
                     blogData = await syncBlogData(item.browseableUrl);
-                    isFromGithubCache = false
-                    await uploadBlogData2Github(item, blogData)
-                }
-                if (blogData) {
-                    if (isFromGithubCache) {
-                        console.log(`>>>从github获取缓存Blog数据: ${item.name}`)
+                    if (blogInfoData.source === 'github') {
+                        console.log(`>>>同步文章:${item.name} 到 github \n`)
+                        await uploadBlogData2Github(item, blogData)
                     }
-                    let data = { ...item, update_time: item.last_edited_time, slug: `posts/${item.slug}`, html: blogData.html, brief: blogData.brief }
-                    const nodeContent = JSON.stringify(data)
-                    const nodeMeta = {
-                        id: createNodeId(data.slug),
-                        parent: null,
-                        children: [],
-                        internal: {
-                            type: `Post`,
-                            mediaType: `text/html`,
-                            content: nodeContent,
-                            contentDigest: createContentDigest(data)
-                        }
-                    }
-                    const node = Object.assign({}, data, nodeMeta)
-                    createNode(node)
+                } else {
+                    blogData = blogInfoData.blogData
                 }
-            }
-        } else {
-            // 未开启github文章缓存，每次都从notion拉取文章
-            for (let item of res) {
+            } else if (blogInfoData.source === 'github') {
+                // 找不到文章 & 启用github缓存，需要同步到github
                 console.log(`>>>开始同步文章:${item.name} from notion \n`)
-                const blogData = await syncBlogData(item.browseableUrl);
-                if (blogData) {
-                    let data = { ...item, update_time: item.last_edited_time, slug: `posts/${item.slug}`, html: blogData.html, brief: blogData.brief }
-                    const nodeContent = JSON.stringify(data)
-                    const nodeMeta = {
-                        id: createNodeId(data.slug),
-                        parent: null,
-                        children: [],
-                        internal: {
-                            type: `Post`,
-                            mediaType: `text/html`,
-                            content: nodeContent,
-                            contentDigest: createContentDigest(data)
-                        }
-                    }
-                    const node = Object.assign({}, data, nodeMeta)
-                    createNode(node)
-                }
+                blogData = await syncBlogData(item.browseableUrl);
+                await uploadBlogData2Github(item, blogData)
             }
-
+            if (blogData) {
+                createBlogPostNode(blogData, item, createNode, createNodeId, createContentDigest)
+            }
         }
-
     }
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4816,7 +4816,7 @@ fs-extra@^5.0.0:
     jsonfile "^4.0.0"
     universalify "^0.1.0"
 
-fs-extra@^7.0.1:
+fs-extra@^7.0.0, fs-extra@^7.0.1:
   version "7.0.1"
   resolved "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz#4f189c44aa123b895f722804f55ea23eadc348e9"
   dependencies:
@@ -4964,6 +4964,14 @@ gatsby-plugin-manifest@^2.0.13:
     "@babel/runtime" "^7.0.0"
     bluebird "^3.5.0"
     sharp "^0.21.0"
+
+gatsby-plugin-netlify-cache@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.npm.taobao.org/gatsby-plugin-netlify-cache/download/gatsby-plugin-netlify-cache-1.2.0.tgz#e68db9c5bd4ae103b4589f9be2a3cb9958750788"
+  integrity sha1-5o25xb1K4QO0WJ+b4qPLmVh1B4g=
+  dependencies:
+    babel-runtime "^6.26.0"
+    fs-extra "^7.0.0"
 
 gatsby-plugin-offline@^2.0.21:
   version "2.0.21"


### PR DESCRIPTION
添加了 `gatsby-plugin-netlify-cache` 插件，使得从 netlify 宿主机环境从获取缓存文章数据成为可能。

文章数据获取策略
1.  优先从本地缓存中获取文章 
2. 如果本地文章不存在，则从 github 仓库获取（开启 github 缓存才有这一步），如果 github 仓库也不存在，则通过 puppetter 抓取。
3. 从本地/github 获取的文章，检测其最后更新时间。如果小于当前 notion api 中获取的最新值，则通过 puppetter 抓取新数据。同步更新数据到 github （开启 github 缓存才有这一步）

目前看来 github 缓存已经没有太大意义，暂时尚未取消此配置，而是作为文章缓存的降级策略。build 速度提高了 50%